### PR TITLE
tm uses the snowball lexicon, not onix

### DIFF
--- a/R/stop_words.R
+++ b/R/stop_words.R
@@ -1,7 +1,7 @@
 #' Various lexicons for English stop words
 #'
 #' English stop words from three lexicons, as a data frame.
-#' The onix and SMART sets are pulled from the tm package. Note
+#' The snowball and SMART sets are pulled from the tm package. Note
 #' that words with non-ASCII characters have been removed.
 #'
 #' @format A data frame with 1149 rows and 2 variables:


### PR DESCRIPTION
`?tm::stopwords` says that it supports the `snowball` list of stopwords (when `kind = 'en'`) and `SMART`.  The length of these vectors matches the grouped by lexicon row counts within `tidytext::stop_words` so I'm guessing the reference to `onix` here is just a typo.