### PR TITLE
Test on release R as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,9 @@ cache: packages
 sudo: false
 warnings_are_errors: true
 
-r:
-- release
-
 matrix:
   include:
+  - r: release
   - r: oldrel
     env: _R_CHECK_FORCE_SUGGESTS_=false
 


### PR DESCRIPTION
In the previous case `r: oldrel` was overwriting the `r: release`, so it was only being checked on r oldrelease. You can tell exactly what settings a given build is running under with the `build_config` tab on travis https://travis-ci.org/juliasilge/tidytext/jobs/334431507/config 