### PR TITLE
Fix tests for corrected tokenize_skip_ngrams()

### DIFF
--- a/tests/testthat/test-unnest-tokens.R
+++ b/tests/testthat/test-unnest-tokens.R
@@ -83,8 +83,8 @@ test_that("tokenizing by ngram and skip ngram works", {
   d <- d2 %>% unnest_tokens(ngram, txt, token = "skip_ngrams", n = 4, k = 2)
   #expect_equal(nrow(d), 189) does not pass on appveyor
   expect_equal(ncol(d), 1)
-  expect_equal(d$ngram[1], "hope thing that the")
-  expect_equal(d$ngram[10], "the sings without and")
+  expect_equal(d$ngram[40], "hope thing that the")
+  expect_equal(d$ngram[400], "the sings without and")
 
 })
 


### PR DESCRIPTION
This pull request fixes two failing tests caused by an imminent release of v0.2 of the tokenizers package. The version 0.1.4 of the tokenizers package currently on CRAN has an incorrect implementation of skip n-grams. (See [this issue](https://github.com/ropensci/tokenizers/issues/24) for details.) The master branch of tokenizers has a fix. As a result the indices used in the tests are now incorrect and I have updated them.

Note that `tokenize_skip_ngrams()` now returns *vastly* more tokens, which is how it is supposed to work, but which might come as a surprise.