### PR TITLE
Fixes nse in cast_sparse

### DIFF
--- a/R/sparse_casters.R
+++ b/R/sparse_casters.R
@@ -38,7 +38,7 @@ cast_sparse <- function(data, row, column, value, ...) {
     value_col <- 1
   }
   data <- ungroup(data)
-  data <- distinct(data, row_col, column_col, .keep_all = TRUE)
+  data <- distinct(data, !!sym(row_col), !!sym(column_col), .keep_all = TRUE)
   row_names <- data[[row_col]]
   col_names <- data[[column_col]]
   if (is.numeric(value_col)) {


### PR DESCRIPTION
Here is a PR regarding the issues #120 and #121. There is a nse error in the `unique` call in cast_sparse: this error triggers an error message inside `distinct` in which `glue::collapse` is used. The latter issue seems to be solved in the dev version of `dplyr`. This PR fixes the `distinct` call.