### PR TITLE
data_frame() soft-deprecated from tibble v2.00 & devtools::revdep_check() deprecated 

### DIFF
--- a/R/corpus_tidiers.R
+++ b/R/corpus_tidiers.R
@@ -63,7 +63,7 @@ tidy.Corpus <- function(x, collapse = "\n", ...) {
     ret
   })
 
-  ret <- as_data_frame(columns)
+  ret <- as_tibble(columns)
 
   # most importantly, add text
   text <- purrr::map(as.list(x), as.character)
@@ -131,7 +131,7 @@ glance.corpus <- function(x, ...) {
   # turn vectors into list columns
   md <- purrr::map_if(md, ~ length(.) > 1, list)
 
-  as_data_frame(md)
+  as_tibble(md)
 }
 
 #' @export

--- a/R/dictionary_tidiers.R
+++ b/R/dictionary_tidiers.R
@@ -12,7 +12,7 @@
 #'
 #' @export
 tidy.dictionary2 <- function(x, regex = FALSE, ...) {
-  ret <- purrr::map_df(x, function(e) data_frame(word = e),
+  ret <- purrr::map_df(x, function(e) tibble(word = e),
                        .id = "category"
   ) %>%
     mutate(category = as.character(category))

--- a/R/lda_tidiers.R
+++ b/R/lda_tidiers.R
@@ -179,7 +179,7 @@ augment_topicmodels <- function(x, data, ...) {
 #'
 #' @export
 glance.LDA <- function(x, ...) {
-  ret <- data_frame(iter = x@iter, terms = x@n)
+  ret <- tibble(iter = x@iter, terms = x@n)
 
   if (!is.null(x@alpha)) {
     ret$alpha <- x@alpha
@@ -191,7 +191,7 @@ glance.LDA <- function(x, ...) {
 #'
 #' @export
 glance.CTM <- function(x, ...) {
-  data_frame(iter = x@iter, terms = x@n)
+  tibble(iter = x@iter, terms = x@n)
 
 }
 

--- a/R/sparse_tidiers.R
+++ b/R/sparse_tidiers.R
@@ -85,7 +85,7 @@ tidy_triplet <- function(x, triplets, row_names = NULL, col_names = NULL) {
     col <- colnames(x)[col]
   }
 
-  ret <- data_frame(row = row, column = col, value = triplets$x)
+  ret <- tibble(row = row, column = col, value = triplets$x)
   ret
 }
 

--- a/R/stm_tidiers.R
+++ b/R/stm_tidiers.R
@@ -202,7 +202,7 @@ augment.STM <- function(x, data, ...) {
 #' @export
 
 glance.STM <- function(x, ...) {
-  ret <- data_frame(
+  ret <- tibble(
     k = as.integer(x$settings$dim$K),
     docs = x$settings$dim$N,
     terms = x$settings$dim$V,

--- a/R/stop_words.R
+++ b/R/stop_words.R
@@ -45,7 +45,7 @@
 #' @export
 #'
 get_stopwords <- function(language = "en", source = "snowball") {
-  data_frame(
+  tibble(
     word = stopwords::stopwords(language = language, source = source),
     lexicon = source
   )

--- a/R/unnest_tokens.R
+++ b/R/unnest_tokens.R
@@ -59,7 +59,7 @@
 #' library(dplyr)
 #' library(janeaustenr)
 #'
-#' d <- data_frame(txt = prideprejudice)
+#' d <- tibble(txt = prideprejudice)
 #' d
 #'
 #' d %>%
@@ -82,7 +82,7 @@
 #'   unnest_tokens(word, txt, token = stringr::str_split, pattern = " ")
 #'
 #' # tokenize HTML
-#' h <- data_frame(row = 1:2,
+#' h <- tibble(row = 1:2,
 #'                 text = c("<h1>Text <b>is</b>", "<a href='example.com'>here</a>"))
 #'
 #' h %>%

--- a/data-raw/setup_data.R
+++ b/data-raw/setup_data.R
@@ -19,9 +19,9 @@ bing_lexicon1 <- readr::read_lines("data-raw/positive-words.txt",
 bing_lexicon2 <- readr::read_lines("data-raw/negative-words.txt",
                                    skip = 35
 )
-bing_lexicon1 <- data_frame(word = bing_lexicon1) %>%
+bing_lexicon1 <- tibble(word = bing_lexicon1) %>%
   mutate(sentiment = "positive", lexicon = "bing")
-bing_lexicon2 <- data_frame(word = bing_lexicon2) %>%
+bing_lexicon2 <- tibble(word = bing_lexicon2) %>%
   mutate(sentiment = "negative", lexicon = "bing")
 bing_lexicon <- bind_rows(bing_lexicon1, bing_lexicon2) %>% arrange(word)
 
@@ -60,9 +60,9 @@ devtools::use_data(sentiments, overwrite = TRUE)
 
 # stop_words dataset ------------------------------------------------------
 
-SMART <- data_frame(word = tm::stopwords("SMART"), lexicon = "SMART")
-snowball <- data_frame(word = tm::stopwords("en"), lexicon = "snowball")
-onix <- data_frame(word = qdapDictionaries::OnixTxtRetToolkitSWL1, lexicon = "onix")
+SMART <- tibble(word = tm::stopwords("SMART"), lexicon = "SMART")
+snowball <- tibble(word = tm::stopwords("en"), lexicon = "snowball")
+onix <- tibble(word = qdapDictionaries::OnixTxtRetToolkitSWL1, lexicon = "onix")
 
 stop_words <- bind_rows(SMART, snowball, onix) %>%
   filter(!stringr::str_detect(word, "[^[:ascii:]]"))

--- a/man/unnest_tokens.Rd
+++ b/man/unnest_tokens.Rd
@@ -62,7 +62,7 @@ This does not yet have support for tokenizing by any unit other than words.
 library(dplyr)
 library(janeaustenr)
 
-d <- data_frame(txt = prideprejudice)
+d <- tibble(txt = prideprejudice)
 d
 
 d \%>\%
@@ -85,7 +85,7 @@ d \%>\%
   unnest_tokens(word, txt, token = stringr::str_split, pattern = " ")
 
 # tokenize HTML
-h <- data_frame(row = 1:2,
+h <- tibble(row = 1:2,
                 text = c("<h1>Text <b>is</b>", "<a href='example.com'>here</a>"))
 
 h \%>\%

--- a/revdep/check.R
+++ b/revdep/check.R
@@ -1,4 +1,4 @@
-library("devtools")
+library("revdepcheck")
 
 res <- revdep_check()
 revdep_check_save_summary()

--- a/tests/testthat/test-corpus-tidiers.R
+++ b/tests/testthat/test-corpus-tidiers.R
@@ -54,7 +54,7 @@ test_that("Can glance a corpus from quanteda using accessor functions", {
       md <- purrr::compact(x$metadata)
       # turn vectors into list columns
       md <- purrr::map_if(md, ~ length(.) > 1, list)
-      as_data_frame(md)
+      as_tibble(md)
     }
     ret_old <- glance_old(x)
 

--- a/tests/testthat/test-sentiments.R
+++ b/tests/testthat/test-sentiments.R
@@ -2,7 +2,7 @@ context("sentiments")
 
 suppressPackageStartupMessages(library(dplyr))
 
-test_data <- data_frame(
+test_data <- tibble(
   line = 1:2,
   text = c(
     "I am happy and joyful",

--- a/tests/testthat/test-sparse-casters.R
+++ b/tests/testthat/test-sparse-casters.R
@@ -2,7 +2,7 @@ context("Sparse casters")
 
 library(Matrix)
 
-dat <- data_frame(
+dat <- tibble(
   a = c("row1", "row1", "row2", "row2", "row2"),
   b = c("col1", "col2", "col1", "col3", "col4"),
   val = 1:5

--- a/tests/testthat/test-stm-tidiers.R
+++ b/tests/testthat/test-stm-tidiers.R
@@ -3,7 +3,7 @@ context("stm tidiers")
 suppressPackageStartupMessages(library(dplyr))
 
 if (require("stm", quietly = TRUE)) {
-  dat <- data_frame(
+  dat <- tibble(
     document = c("row1", "row1", "row2", "row2", "row2"),
     term = c("col1", "col2", "col1", "col3", "col4"),
     n = 1:5

--- a/tests/testthat/test-tf-idf.R
+++ b/tests/testthat/test-tf-idf.R
@@ -1,6 +1,6 @@
 context("tf-idf calculation")
 
-w <- data_frame(
+w <- tibble(
   document = rep(1:2, each = 5),
   word = c(
     "the", "quick", "brown", "fox", "jumped",
@@ -45,7 +45,7 @@ test_that("Can calculate TF-IDF", {
 
 test_that("TF-IDF works when the document ID is a number", {
   # example thanks to https://github.com/juliasilge/tidytext/issues/31
-  my_corpus <- dplyr::data_frame(
+  my_corpus <- dplyr::tibble(
     id = rep(c(2, 3), each = 3),
     word = c("an", "interesting", "text", "a", "boring", "text"),
     n = c(1, 1, 3, 1, 2, 1)
@@ -58,7 +58,7 @@ test_that("TF-IDF works when the document ID is a number", {
 
 
 test_that("tf-idf with tidyeval works", {
-  d <- data_frame(txt = c(
+  d <- tibble(txt = c(
     "Because I could not stop for Death -",
     "He kindly stopped for me -"
   ))

--- a/tests/testthat/test-unnest-tokens.R
+++ b/tests/testthat/test-unnest-tokens.R
@@ -5,7 +5,7 @@ context("Unnesting tokens")
 suppressPackageStartupMessages(library(dplyr))
 
 test_that("tokenizing by character works", {
-  d <- data_frame(txt = "Emily Dickinson")
+  d <- tibble(txt = "Emily Dickinson")
   d <- d %>% unnest_tokens(char, txt, token = "characters")
   expect_equal(nrow(d), 14)
   expect_equal(ncol(d), 1)
@@ -13,7 +13,7 @@ test_that("tokenizing by character works", {
 })
 
 test_that("tokenizing by character shingles works", {
-  d <- data_frame(txt = "tidytext is the best")
+  d <- tibble(txt = "tidytext is the best")
   d <- d %>% unnest_tokens(char_ngram, txt, token = "character_shingles", n = 4)
   expect_equal(nrow(d), 14)
   expect_equal(ncol(d), 1)
@@ -21,7 +21,7 @@ test_that("tokenizing by character shingles works", {
 })
 
 test_that("tokenizing by character shingles can include whitespace/punctuation", {
-  d <- data_frame(txt = "tidytext is the best!")
+  d <- tibble(txt = "tidytext is the best!")
   d <- d %>% unnest_tokens(char_ngram, txt,
                            token = "character_shingles",
                            strip_non_alphanum = FALSE
@@ -32,7 +32,7 @@ test_that("tokenizing by character shingles can include whitespace/punctuation",
 })
 
 test_that("tokenizing by word works", {
-  d <- data_frame(txt = c(
+  d <- tibble(txt = c(
     "Because I could not stop for Death -",
     "He kindly stopped for me -"
   ))
@@ -43,7 +43,7 @@ test_that("tokenizing by word works", {
 })
 
 test_that("tokenizing errors with appropriate message", {
-  d <- data_frame(txt = c(
+  d <- tibble(txt = c(
     "Because I could not stop for Death -",
     "He kindly stopped for me -"
   ))
@@ -54,7 +54,7 @@ test_that("tokenizing errors with appropriate message", {
 })
 
 test_that("tokenizing by sentence works", {
-  orig <- data_frame(txt = c(
+  orig <- tibble(txt = c(
     "I'm Nobody! Who are you?",
     "Are you - Nobody - too?",
     "Then there’s a pair of us!",
@@ -76,7 +76,7 @@ test_that("tokenizing by sentence works", {
 
 
 test_that("tokenizing by ngram and skip ngram works", {
-  d2 <- data_frame(txt = c(
+  d2 <- tibble(txt = c(
     "Hope is the thing with feathers",
     "That perches in the soul",
     "And sings the tune without the words",
@@ -107,7 +107,7 @@ test_that("tokenizing by ngram and skip ngram works", {
 })
 
 test_that("tokenizing with a custom function works", {
-  orig <- data_frame(txt = c(
+  orig <- tibble(txt = c(
     "I'm Nobody! Who are you?",
     "Are you - Nobody - too?",
     "Then there’s a pair of us!",
@@ -130,7 +130,7 @@ test_that("tokenizing with a custom function works", {
 })
 
 test_that("tokenizing with standard evaluation works", {
-  d <- data_frame(txt = c(
+  d <- tibble(txt = c(
     "Because I could not stop for Death -",
     "He kindly stopped for me -"
   ))
@@ -141,7 +141,7 @@ test_that("tokenizing with standard evaluation works", {
 })
 
 test_that("tokenizing with tidyeval works", {
-  d <- data_frame(txt = c(
+  d <- tibble(txt = c(
     "Because I could not stop for Death -",
     "He kindly stopped for me -"
   ))
@@ -154,7 +154,7 @@ test_that("tokenizing with tidyeval works", {
 })
 
 test_that("tokenizing with to_lower = FALSE works", {
-  orig <- data_frame(txt = c(
+  orig <- tibble(txt = c(
     "Because I could not stop for Death -",
     "He kindly stopped for me -"
   ))
@@ -173,7 +173,7 @@ test_that("tokenizing with to_lower = FALSE works", {
 
 
 test_that("unnest_tokens raises an error if custom tokenizer gives bad output", {
-  d <- data_frame(txt = "Emily Dickinson")
+  d <- tibble(txt = "Emily Dickinson")
 
   expect_error(
     unnest_tokens(d, word, txt, token = function(e) c("a", "b")),
@@ -187,7 +187,7 @@ test_that("unnest_tokens raises an error if custom tokenizer gives bad output", 
 
 
 test_that("tokenizing HTML works", {
-  h <- data_frame(
+  h <- tibble(
     row = 1:2,
     text = c("<h1>Text <b>is<b>", "<a href='example.com'>here</a>")
   )
@@ -204,7 +204,7 @@ test_that("tokenizing HTML works", {
 
 
 test_that("tokenizing LaTeX works", {
-  h <- data_frame(
+  h <- tibble(
     row = 1:4,
     text = c(
       "\\textbf{text} \\emph{is}", "\\begin{itemize}",
@@ -258,7 +258,7 @@ test_that("Tokenizing a two-column data.frame with one non-text column works", {
 
 
 test_that("Tokenizing with NA values in columns behaves as expected", {
-  text <- data_frame(
+  text <- tibble(
     line = c(1:2, NA),
     txt = c(
       NA,
@@ -280,7 +280,7 @@ test_that("Tokenizing with NA values in columns behaves as expected", {
 
 
 test_that("Trying to tokenize a non-text format with words raises an error", {
-  d <- data_frame(txt = "Emily Dickinson")
+  d <- tibble(txt = "Emily Dickinson")
   expect_error(
     unnest_tokens(d, word, txt,
                   token = "sentences",
@@ -369,7 +369,7 @@ test_that("Tokenizing a data frame with list columns works", {
 })
 
 test_that("Tokenizing a tbl_df with list columns works", {
-  df <- data_frame(
+  df <- tibble(
     txt = c(
       "Because I could not stop for Death -",
       "He kindly stopped for me -"
@@ -389,7 +389,7 @@ test_that("Tokenizing a tbl_df with list columns works", {
 })
 
 test_that("Can't tokenize with list columns with collapse = TRUE", {
-  df <- data_frame(
+  df <- tibble(
     txt = c(
       "Because I could not stop for Death -",
       "He kindly stopped for me -"

--- a/vignettes/tidytext.Rmd
+++ b/vignettes/tidytext.Rmd
@@ -165,7 +165,7 @@ Lots of useful work can be done by tokenizing at the word level, but sometimes i
 is a sad sentence, not a happy one, because of negation. The [Stanford CoreNLP](http://stanfordnlp.github.io/CoreNLP/) tools and the [sentimentr R package](https://cran.r-project.org/package=sentimentr) are examples of such sentiment analysis algorithms. For these, we may want to tokenize text into sentences.
 
 ```{r}
-PandP_sentences <- data_frame(text = prideprejudice) %>% 
+PandP_sentences <- tibble(text = prideprejudice) %>% 
   unnest_tokens(sentence, text, token = "sentences")
 ```
 


### PR DESCRIPTION
Down the rabbit hole  ... I started with tidy-text-mining book and I ended up here. :construction_worker:

**Breaking changes** from [tibble v2.00](https://github.com/tidyverse/tibble/releases/tag/v2.0.0)
* as.tibble() and as_data_frame() are officially deprecated and not generic anymore, please use/implement as_tibble() (#111).
* data_frame() and frame_data() are soft-deprecated, please use tibble() or tribble() (#111).
