### PR TITLE
use requireNamespace to detect textdata

### DIFF
--- a/R/sentiments.R
+++ b/R/sentiments.R
@@ -55,12 +55,22 @@ get_sentiments <- function(lexicon = c("afinn", "bing", "loughran")) {
   lex <- match.arg(lexicon)
 
   if (lex == "afinn") {
+    if (!requireNamespace("textdata", quietly = TRUE)){
+      stop("The textdata package is required to get the afinn lexicon. \nPlease run install.packages(\"textdata\") to use this functionality.",
+        call. = FALSE
+      )
+    }
     return(textdata::lexicon_afinn())
   } else if (lex == "nrc") {
     stop(paste("The NRC lexicon is no longer available within this package.\n",
                "Learn more about this dataset here:\n",
                "https://saifmohammad.com/WebPages/NRC-Emotion-Lexicon.htm"))
   } else if (lex == "loughran") {
+    if (!requireNamespace("textdata", quietly = TRUE)){
+      stop("The textdata package is required to get the loughran lexicon. \nPlease run install.packages(\"textdata\") to use this functionality.",
+        call. = FALSE
+      )
+    }
     return(textdata::lexicon_loughran())
   } else if (lex == "bing") {
     return(sentiments)


### PR DESCRIPTION
This PR follows the recommendation from the [Namespaces](http://r-pkgs.had.co.nz/namespace.html) chapter by Hadley, and returns a more informative error and suggested action if the `textdata` package is not installed.

> Use `requireNamespace(x, quietly = TRUE)` inside a package if you want a specific action (e.g. throw an error) depending on whether or not a suggested package is installed.