### PR TITLE
Fix for quanteda v2

### DIFF
--- a/R/unnest_regex.R
+++ b/R/unnest_regex.R
@@ -20,7 +20,7 @@
 #' d <- tibble(txt = prideprejudice)
 #'
 #' d %>%
-#'   unnest_regex(word, txt, pattern = "Chapter [\\d]")
+#'   unnest_regex(word, txt, pattern = "Chapter [\\\\d]")
 #'
 unnest_regex <- function(
   tbl,

--- a/R/unnest_tokens.R
+++ b/R/unnest_tokens.R
@@ -74,7 +74,7 @@
 #'   unnest_tokens(ngram, txt, token = "ngrams", n = 2)
 #'
 #' d %>%
-#'   unnest_tokens(chapter, txt, token = "regex", pattern = "Chapter [\\d]")
+#'   unnest_tokens(chapter, txt, token = "regex", pattern = "Chapter [\\\\d]")
 #'
 #' d %>%
 #'   unnest_tokens(shingle, txt, token = "character_shingles", n = 4)

--- a/tests/testthat/test-corpus-tidiers.R
+++ b/tests/testthat/test-corpus-tidiers.R
@@ -35,7 +35,9 @@ test_that("Can tidy corpus from quanteda using accessor functions", {
     x <- quanteda::data_corpus_inaugural
 
     ## old method
-    ret_old <- tbl_df(x$documents) %>%
+    ret_old <- tbl_df(data.frame(texts = quanteda::texts(x),
+                                 quanteda::docvars(x),
+                                 stringsAsFactors = FALSE)) %>%
       rename(text = texts)
 
     ## new method
@@ -51,7 +53,7 @@ test_that("Can glance a corpus from quanteda using accessor functions", {
 
     ## old method
     glance_old <- function(x, ...) {
-      md <- purrr::compact(x$metadata)
+      md <- purrr::compact(quanteda::metacorpus(x))
       # turn vectors into list columns
       md <- purrr::map_if(md, ~ length(.) > 1, list)
       as_tibble(md)


### PR DESCRIPTION
Makes code compatible with the forthcoming **quanteda** v2, while retaining compatibility with the current (v1.5.x) releases.

Also fixes an escape character issue that breaks the roxygenation with **roxygen2** v7.0.x.

Fixes https://github.com/quanteda/quanteda/issues/1783.