### PR TITLE
updated get_sentiments() documentation to match new afinn column name

### DIFF
--- a/R/sentiments.R
+++ b/R/sentiments.R
@@ -36,7 +36,7 @@
 #' either "afinn", "bing", "nrc", or "loughran"
 #'
 #' @return A tbl_df with a \code{word} column, and either a \code{sentiment}
-#' column (if \code{lexicon} is not "afinn") or a numeric \code{score} column
+#' column (if \code{lexicon} is not "afinn") or a numeric \code{value} column
 #' (if \code{lexicon} is "afinn").
 #'
 #' @examples

--- a/man/get_sentiments.Rd
+++ b/man/get_sentiments.Rd
@@ -12,7 +12,7 @@ either "afinn", "bing", "nrc", or "loughran"}
 }
 \value{
 A tbl_df with a \code{word} column, and either a \code{sentiment}
-column (if \code{lexicon} is not "afinn") or a numeric \code{score} column
+column (if \code{lexicon} is not "afinn") or a numeric \code{value} column
 (if \code{lexicon} is "afinn").
 }
 \description{


### PR DESCRIPTION
Looks like earlier this year textdata::lexicon_afinn() was changed so that it returns a tibble where the numeric column is now named "value" instead of "score". The documentation for tidytext::get_sentiments() still refers to "score", so I updated the text and re-ran roxygenize to carry it over.