### PR TITLE
Add test for `.data` pronoun back in

### DIFF
--- a/tests/testthat/test-unnest-tokens.R
+++ b/tests/testthat/test-unnest-tokens.R
@@ -152,6 +152,17 @@ test_that("tokenizing with a custom function works", {
   expect_equal(d2$unit[4], "you know!")
 })
 
+test_that("tokenizing with standard evaluation works", {
+  d <- tibble(txt = c(
+    "Because I could not stop for Death -",
+    "He kindly stopped for me -"
+  ))
+  d <- d %>% unnest_tokens("word", "txt")
+  expect_equal(nrow(d), 12)
+  expect_equal(ncol(d), 1)
+  expect_equal(d$word[1], "because")
+})
+
 test_that("tokenizing with tidyeval works", {
   d <- tibble(txt = c(
     "Because I could not stop for Death -",


### PR DESCRIPTION
I'm having trouble getting **both** this usage:

```r
d %>% unnest_tokens(.data$word, .data$txt)
```

**And** this usage to work:

```r
d %>% unnest_tokens("word", "txt")
```

I think the problem is that the `.data` pronoun isn't really great for new columns being created, but [someone is using it that way in a package](https://github.com/oriolarques/GSEAmining/blob/master/R/gm_clust.R) to avoid CRAN check notes.


Current problems with the version with string inputs, because of [these embraces](https://github.com/juliasilge/tidytext/blob/master/R/unnest_tokens.R#L175-L183) I used for handling new columns:

``` r
library(tidytext)
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
d <- tibble(
  txt = c(
    "Because I could not stop for Death -",
    "He kindly stopped for me -",
    "The Carriage held but just Ourselves –",
    "And Immortality.",
    "We slowly drove – He knew no haste",
    "And I had put away",
    "My labor and my leisure too,",
    "For His Civility –"),
  group = c("a", "a", "b", "b", "c", "a", "c", "c")
)

d %>% unnest_tokens(token, txt)
#> # A tibble: 41 x 2
#>    group token  
#>    <chr> <chr>  
#>  1 a     because
#>  2 a     i      
#>  3 a     could  
#>  4 a     not    
#>  5 a     stop   
#>  6 a     for    
#>  7 a     death  
#>  8 a     he     
#>  9 a     kindly 
#> 10 a     stopped
#> # … with 31 more rows
## should remove `txt` column, should not have quotes in column name
d %>% unnest_tokens("token", "txt")
#> # A tibble: 41 x 3
#>    txt                                  group `"token"`
#>    <chr>                                <chr> <chr>    
#>  1 Because I could not stop for Death - a     because  
#>  2 Because I could not stop for Death - a     i        
#>  3 Because I could not stop for Death - a     could    
#>  4 Because I could not stop for Death - a     not      
#>  5 Because I could not stop for Death - a     stop     
#>  6 Because I could not stop for Death - a     for      
#>  7 Because I could not stop for Death - a     death    
#>  8 He kindly stopped for me -           a     he       
#>  9 He kindly stopped for me -           a     kindly   
#> 10 He kindly stopped for me -           a     stopped  
#> # … with 31 more rows
d %>% unnest_tokens(.data$token, .data$txt)
#> # A tibble: 41 x 2
#>    group token  
#>    <chr> <chr>  
#>  1 a     because
#>  2 a     i      
#>  3 a     could  
#>  4 a     not    
#>  5 a     stop   
#>  6 a     for    
#>  7 a     death  
#>  8 a     he     
#>  9 a     kindly 
#> 10 a     stopped
#> # … with 31 more rows
```

<sup>Created on 2020-12-17 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>
