### PR TITLE
Add back in test for using `.data` pronoun

### DIFF
--- a/tests/testthat/test-unnest-tokens.R
+++ b/tests/testthat/test-unnest-tokens.R
@@ -41,6 +41,9 @@ test_that("tokenizing by word works", {
   expect_equal(ncol(d1), 2)
   expect_equal(d1$word[1], "because")
 
+  d2 <- d %>% unnest_tokens(.data$word, .data$txt)
+  expect_equal(d1, d2)
+
   d3 <- d %>% group_by(line) %>% unnest_tokens(word, txt)
   expect_equal(d1, ungroup(d3))
 


### PR DESCRIPTION
I'm having trouble getting **both** this usage:

```r
d %>% unnest_tokens(.data$word, .data$txt)
```

**And** this usage to work:

```r
d %>% unnest_tokens("word", "txt")
```

I think the problem is that the `.data` pronoun isn't really great for new columns being created, but [someone is using it that way in a package](https://github.com/oriolarques/GSEAmining/blob/master/R/gm_clust.R) to avoid CRAN check notes.


Current problems with the version with the `.data` pronoun, because of [these bang-bangs](https://github.com/juliasilge/tidytext/blob/master/R/unnest_tokens.R#L175-L183) I used for handling new columns:

``` r
library(tidytext)
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
d <- tibble(
  txt = c(
    "Because I could not stop for Death -",
    "He kindly stopped for me -",
    "The Carriage held but just Ourselves –",
    "And Immortality.",
    "We slowly drove – He knew no haste",
    "And I had put away",
    "My labor and my leisure too,",
    "For His Civility –"),
  group = c("a", "a", "b", "b", "c", "a", "c", "c")
)

d %>% unnest_tokens(token, txt)
#> # A tibble: 41 x 2
#>    group token  
#>    <chr> <chr>  
#>  1 a     because
#>  2 a     i      
#>  3 a     could  
#>  4 a     not    
#>  5 a     stop   
#>  6 a     for    
#>  7 a     death  
#>  8 a     he     
#>  9 a     kindly 
#> 10 a     stopped
#> # … with 31 more rows
d %>% unnest_tokens("token", "txt")
#> # A tibble: 41 x 2
#>    group token  
#>    <chr> <chr>  
#>  1 a     because
#>  2 a     i      
#>  3 a     could  
#>  4 a     not    
#>  5 a     stop   
#>  6 a     for    
#>  7 a     death  
#>  8 a     he     
#>  9 a     kindly 
#> 10 a     stopped
#> # … with 31 more rows
d %>% unnest_tokens(.data$token, .data$txt)
#> Error: The LHS of `:=` must be a string or a symbol
```

<sup>Created on 2020-12-17 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>