### PR TITLE
Fix `abort()` call

### DIFF
--- a/R/unnest_tokens.R
+++ b/R/unnest_tokens.R
@@ -154,10 +154,10 @@ unnest_tokens <- function(tbl, output, input, token = "words",
   output_lst <- tokenfunc(col, ...)
 
   if (!(is.list(output_lst) && length(output_lst) == nrow(tbl))) {
-    rlang::abort(
+    rlang::abort(sprintf(
       "Expected output of tokenizing function to be a list of length ",
       nrow(tbl)
-    )
+    ))
   }
 
   output <- quo_name(output)


### PR DESCRIPTION
I see in revdep checks:

```
Running the tests in ‘tests/testthat.R’ failed.
Last 13 lines of output:
  Actual message: "`class` must be a character vector."
```

`abort()` is now stricter regarding the sort of objects passed as `class` argument and this uncovered a bug in tidytext. You can fix it with this patch.

We plan to release rlang 1.0.0 within 2 to 4 weeks.