### PR TITLE
`tidy.STM` with content variable in stm

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * `scale_x/y_reordered()` now uses a function `labels` as its main input (#200)
 * Fixed how `to_lower` is passed to underlying tokenization function for character shingles (#208)
+* Added support for tidying STM models that use `content`, thanks to @jonathanvoelkle (#209)
 
 # tidytext 0.3.2
 

--- a/R/stm_tidiers.R
+++ b/R/stm_tidiers.R
@@ -111,12 +111,8 @@ tidy.STM <- function(x, matrix = c("beta", "gamma", "theta"), log = FALSE,
     tibble::as_tibble()
 
   if (matrix == "beta") {
-    if (length(ret) > 1) {
-      ret <- transmute(ret, topic = Var1, term = x$vocab[Var2], beta = value,
-                       yvarlevel = x$settings$covariates$yvarlevels[as.integer(L1)])
-    } else {
-      ret <- transmute(ret, topic = Var1, term = x$vocab[Var2], beta = value)
-    }
+    ret <- transmute(ret, topic = Var1, term = x$vocab[Var2], beta = value,
+                     yvarlevel = x$settings$covariates$yvarlevels[as.integer(L1)])
   } else {
     ret <- transmute(ret, document = Var1, topic = Var2, gamma = value)
     if (!is.null(document_names)) {

--- a/R/stm_tidiers.R
+++ b/R/stm_tidiers.R
@@ -102,7 +102,7 @@ tidy.STM <- function(x, matrix = c("beta", "gamma", "theta"), log = FALSE,
                      document_names = NULL, ...) {
   matrix <- match.arg(matrix)
   if (matrix == "beta") {
-    mat <- x$beta
+    mat <- x$beta$logbeta
   } else {
     mat <- x$theta
   }
@@ -111,7 +111,12 @@ tidy.STM <- function(x, matrix = c("beta", "gamma", "theta"), log = FALSE,
     tibble::as_tibble()
 
   if (matrix == "beta") {
-    ret <- transmute(ret, topic = Var1, term = x$vocab[Var2], beta = value)
+    if (length(ret) > 1) {
+      ret <- transmute(ret, topic = Var1, term = x$vocab[Var2], beta = value,
+                       yvarlevel = x$settings$covariates$yvarlevels[as.integer(L1)])
+    } else {
+      ret <- transmute(ret, topic = Var1, term = x$vocab[Var2], beta = value)
+    }
   } else {
     ret <- transmute(ret, document = Var1, topic = Var2, gamma = value)
     if (!is.null(document_names)) {

--- a/R/stm_tidiers.R
+++ b/R/stm_tidiers.R
@@ -112,7 +112,7 @@ tidy.STM <- function(x, matrix = c("beta", "gamma", "theta"), log = FALSE,
 
   if (matrix == "beta") {
     ret <- transmute(ret, topic = Var1, term = x$vocab[Var2], beta = value,
-                     yvarlevel = x$settings$covariates$yvarlevels[as.integer(L1)])
+                     y.level = x$settings$covariates$yvarlevels[as.integer(L1)])
   } else {
     ret <- transmute(ret, document = Var1, topic = Var2, gamma = value)
     if (!is.null(document_names)) {

--- a/tidytext.Rproj
+++ b/tidytext.Rproj
@@ -17,5 +17,6 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
+PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
I realized that when then document-level `content` covariate is set in `stm`, the beta-list contains also the interaction coefficients besides the topic-term probabilities and provides a beta-matrix for each covariate separately, in which case `tidy.STM` returns a tibble where some topics/terms are NAs, and multiple values for topic-term combinations (exactly the number of levels in the covariate) - reprex below. 

So I restricted it to only return the beta-values and added a column to the beta tibble which indicates the covariate.

``` r
library(stm)
#> stm v1.3.6 successfully loaded. See ?stm for help. 
#>  Papers, resources, and other materials at structuraltopicmodel.com
library(tidytext)
topic_model_content <- stm(poliblog5k.docs, poliblog5k.voc, K = 20,
            prevalence = ~ rating + s(day), content = ~ rating,
            max.em.its = 3, data = poliblog5k.meta, init.type = "Spectral",
            verbose = F)
td_beta_content <- tidy(topic_model_content)
td_beta_content
#> # A tibble: 271,097 × 3
#>    topic term      beta
#>    <int> <chr>    <dbl>
#>  1    NA <NA>  0.000133
#>  2    NA <NA>  0.000292
#>  3    NA <NA>  0.000269
#>  4    NA <NA>  0.000536
#>  5    NA <NA>  0.000376
#>  6    NA <NA>  0.000109
#>  7    NA <NA>  0.000294
#>  8    NA <NA>  0.000101
#>  9    NA <NA>  0.000130
#> 10    NA <NA>  0.000246
#> # … with 271,087 more rows
```

<sup>Created on 2022-04-20 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
