### PR TITLE
Fix bug in stm tidier for FREX words

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidytext (development version)
 
+* Fixed bug for FREX stm tidier (#228)
+
 # tidytext 0.4.0
 
 * hunspell is now a suggested dependency, thanks to @MichaelChirico (#221)

--- a/R/stm_tidiers.R
+++ b/R/stm_tidiers.R
@@ -115,7 +115,7 @@ tidy_stm_frex <- function(x, ...) {
   logbeta <- x$beta$logbeta[[1]]
   word_counts <- x$settings$dim$wcounts$x
   vocab <- x$vocab
-  frex <- stm::calcfrex(logbeta, ..., word_counts)
+  frex <- stm::calcfrex(logbeta, ..., wordcounts = word_counts)
   pivot_stm_longer(frex, vocab)
 }
 


### PR DESCRIPTION
The argument after the dots needs to be named.