### PR TITLE
Pin specific version of vdiffr, for R-devel problems

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,7 +42,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: 
+            any::rcmdcheck,
+            vdiffr@1.0.5
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
Related to r-lib/vdiffr#137

I'm seeing failures for vdiffr on R-devel in my CI so let's try avoiding the problem with an older version of vdiffr.