### PR TITLE
Improve clarity of one-token-per-row explanation

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -70,7 +70,7 @@ original_books <- austen_books() |>
 original_books
 ```
 
-To work with this as a tidy dataset, we need to restructure it as **one-token-per-row** format. The `unnest_tokens()` function is a way to convert a dataframe with a text column to be one-token-per-row:
+To work with this as a tidy dataset, we need to restructure it into a one-token-per-row format, where each row represents a single token. The `unnest_tokens()` function is a way to convert a dataframe with a text column to be one-token-per-row:
 
 ```{r}
 library(tidytext)


### PR DESCRIPTION
This PR improves documentation clarity by expanding the explanation of the one-token-per-row format for new users.
